### PR TITLE
Reduced image size and documented how to use local user/group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM golang:1.9.7-alpine3.7
-RUN apk update && apk add git
+FROM golang:1.11.2-alpine AS build
+RUN apk add --no-cache git
 RUN go get github.com/jsha/minica
+
+FROM alpine:3.8
+COPY --from=build /go/bin/minica /usr/local/bin/minica
 RUN mkdir /output
 WORKDIR /output
 ENTRYPOINT ["minica"]

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
 ## Usage
 
 ```
-$ docker run -it -v /your/desired/output/dir:/output ryantk/minica --domains foo.dev
+$ docker run --user $(id -u):$(id -g) -it -v /your/desired/output/dir:/output ryantk/minica --domains foo.dev
 ```
 
 Then retreive your certificates:


### PR DESCRIPTION
- Reduced image size from 288MB to 7.84MB by using alpine as base image and run go get in builder image.
- when no user/group is set the generated certificates belong to root/root. This may not be desired when running the image as non root. Updated the documentation accordingly. 
